### PR TITLE
Relax JWT authentication rules to ignore mismatched protocol or hostname.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+* Relax authentication rules for verifying JWT audience to ignore mismatched protocol or hostname.
+  In a loadbalanced environment, the `ServerRequestInterface` may not always have accurate information on whether
+  the request was http/s, or the external hostname that was routed to the appserver. Therefore only validate the
+  path and querystring (which identifies the operation to be performed). This still prevents reusing a token to perform
+  a different operation. You should anyway be using different service accounts for different environments, which in
+  itself protects against using e.g. a QA token to authorise the same operation in production. Therefore the hostname
+  etc is not relevant to the authentication/authorisation.
+
 ## v0.2.0 (2020-12-11)
 
 * Capture more task metadata and memory usage in the log_context when logging task execution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v0.2.1 (2021-01-18)
+
 * Relax authentication rules for verifying JWT audience to ignore mismatched protocol or hostname.
   In a loadbalanced environment, the `ServerRequestInterface` may not always have accurate information on whether
   the request was http/s, or the external hostname that was routed to the appserver. Therefore only validate the

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-bcmath": "^7",
         "google/cloud-tasks": "^1.8",
         "google/protobuf": "^3.13.0.1",
-        "ingenerator/oidc-token-verifier": "^0.1",
+        "ingenerator/oidc-token-verifier": "^0.1.1",
         "ingenerator/php-utils": "^1.7",
         "psr/http-message": "^1.0",
         "symfony/polyfill-php80": "^1.20"

--- a/src/Server/Middleware/TaskRequestAuthenticatingMiddleware.php
+++ b/src/Server/Middleware/TaskRequestAuthenticatingMiddleware.php
@@ -69,8 +69,8 @@ class TaskRequestAuthenticatingMiddleware implements TaskHandlerMiddleware
             $token,
             new TokenConstraints(
                 [
-                    'audience_exact' => $request->getFullUrl(),
-                    'email_exact'    => $expect_signer,
+                    'audience_path_and_query' => $request->getFullUrl(),
+                    'email_exact'             => $expect_signer,
                 ]
             )
         );

--- a/test/unit/Server/Middleware/TaskRequestAuthenticatingMiddlewareTest.php
+++ b/test/unit/Server/Middleware/TaskRequestAuthenticatingMiddlewareTest.php
@@ -87,7 +87,7 @@ class TaskRequestAuthenticatingMiddlewareTest extends TestCase
         );
     }
 
-    public function test_it_validates_token_with_task_type_signer_email_and_task_url_as_audience()
+    public function test_it_validates_token_with_task_type_signer_email_and_task_url_as_audience_path_and_query()
     {
         $this->task_type_config = TaskTypeConfigStub::withTaskType(
             'my-custom-task',
@@ -111,8 +111,8 @@ class TaskRequestAuthenticatingMiddlewareTest extends TestCase
         $this->token_verifier->assertVerifiedOnce(
             'abc215.1242121asd2.ad7215724',
             [
-                'audience_exact' => 'http://foo.bar.com/_task?foo=bar&data=some%20thing',
-                'email_exact'    => 'foo@bar.serviceaccount.com',
+                'audience_path_and_query' => 'http://foo.bar.com/_task?foo=bar&data=some%20thing',
+                'email_exact'             => 'foo@bar.serviceaccount.com',
             ]
         );
     }


### PR DESCRIPTION
In a loadbalanced environment, the `ServerRequestInterface` may not always have accurate information
on whether the request was http/s, or the external hostname that was routed to the appserver.
Therefore only validate the path and querystring (which identifies the operation to be performed).
This still prevents reusing a token to perform a different operation. You should anyway be using
different service accounts for different environments, which in itself protects against using
e.g. a QA token to authorise the same operation in production. Therefore the hostname etc is not
relevant to the authentication/authorisation.