### PR TITLE
Fix asserting date / time options in MockTaskCreator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Fix MockTaskCreator so that it can compare the DateTimeImmutable for schedule_send_after and DateInterval for
+  throttle_interval. These were previously compared by strict equality, which doesn't work.
+ 
 ## v0.2.1 (2021-01-18)
 
 * Relax authentication rules for verifying JWT audience to ignore mismatched protocol or hostname.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v0.2.2 (2021-04-09)
+
 * Fix MockTaskCreator so that it can compare the DateTimeImmutable for schedule_send_after and DateInterval for
   throttle_interval. These were previously compared by strict equality, which doesn't work.
  

--- a/src/TestHelpers/Client/MockCloudTaskCreator.php
+++ b/src/TestHelpers/Client/MockCloudTaskCreator.php
@@ -7,11 +7,12 @@ namespace Ingenerator\CloudTasksWrapper\TestHelpers\Client;
 use Ingenerator\CloudTasksWrapper\Client\CreateTaskOptions;
 use Ingenerator\CloudTasksWrapper\Client\TaskCreationFailedException;
 use Ingenerator\CloudTasksWrapper\Client\TaskCreator;
+use Ingenerator\PHPUtils\DateTime\DateString;
 use PHPUnit\Framework\Assert;
 
 class MockCloudTaskCreator implements TaskCreator
 {
-    protected array $calls = [];
+    protected array       $calls      = [];
 
     protected ?\Throwable $will_throw = NULL;
 
@@ -28,7 +29,7 @@ class MockCloudTaskCreator implements TaskCreator
         $options       ??= new CreateTaskOptions([]);
         $this->calls[] = [
             'task_type' => $task_type,
-            'options'   => $options->getRawOptions(),
+            'options'   => $this->convertOptionsToScalars($options->getRawOptions()),
         ];
 
         if ($this->will_throw) {
@@ -45,7 +46,42 @@ class MockCloudTaskCreator implements TaskCreator
 
     public function assertQueuedExactly(array $expect): void
     {
-        Assert::assertSame($expect, $this->calls);
+        Assert::assertSame(
+            array_map(
+                function ($call) {
+                    $call['options'] = $this->convertOptionsToScalars($call['options']);
+
+                    return $call;
+                },
+                $expect
+            ),
+            $this->calls
+        );
+    }
+
+    /**
+     * Convert all options values to scalars that can be compared with strict equality
+     *
+     * The testcase will almost never have the actual object instances that were passed for schedule_send_after
+     * or throttle_interval. So they need to be converted to some sort of scalar that we can compare.
+     *
+     * @param array $opts
+     *
+     * @return array
+     */
+    private function convertOptionsToScalars(array $opts): array
+    {
+        if ($opts['schedule_send_after'] ?? NULL) {
+            $opts['schedule_send_after'] = DateString::format($opts['schedule_send_after'], 'Y-m-d H:i:s.u');
+        }
+
+        if ($opts['throttle_interval'] ?? NULL) {
+            // DateInterval is hard to format back to the interval string. JSON the values that have any value should
+            // be enough to make it comparable and vaguely understandable in the diff.
+            $opts['throttle_interval'] = \json_encode(array_filter((array) $opts['throttle_interval']));
+        }
+
+        return $opts;
     }
 
 }


### PR DESCRIPTION
For easier assertions in test code, store a string not the original
DateTimeImmutable object.