### PR TITLE
Improve support for values sent in the request body (form-encoded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v0.2.3 (2021-06-03)
+
 * Provide assertQueuedExactlyOne() on MockCloudTaskCreator to assert creation of a single task with
   expected type. Useful when other tests cover the task details and you just want
   to be sure it fired / didn't fire.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Improve support for values sent in the POST body of a task request. These can now be included in
+  TaskRequestStub instances (provide the `parsed_body` option to ::with()). The TaskRequest also
+  includes a sugar method to grab a body (POST) value and throw if not present or empty.
+
 ## v0.2.2 (2021-04-09)
 
 * Fix MockTaskCreator so that it can compare the DateTimeImmutable for schedule_send_after and DateInterval for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Provide assertQueuedExactlyOne() on MockCloudTaskCreator to assert creation of a single task with
+  expected type. Useful when other tests cover the task details and you just want
+  to be sure it fired / didn't fire.
+
 * Improve support for values sent in the POST body of a task request. These can now be included in
   TaskRequestStub instances (provide the `parsed_body` option to ::with()). The TaskRequest also
   includes a sugar method to grab a body (POST) value and throw if not present or empty.

--- a/src/Server/TaskRequest.php
+++ b/src/Server/TaskRequest.php
@@ -179,4 +179,27 @@ class TaskRequest
         return $var;
     }
 
+    /**
+     * Requires a non-empty value from the task body (which is assumed to be POST variables)
+     *
+     * Used for the common case where you need one or two simple values in form-encoded POST
+     * data sent with the request, and you can't do anything without them.
+     *
+     * The exception short-circuits further execution but will be mapped to an HTTP response
+     * that tells CloudTasks not to bother retrying.
+     *
+     * @param string $param
+     *
+     * @return string
+     */
+    public function requireBodyField(string $key)
+    {
+        $value = $this->request->getParsedBody()[$key] ?? NULL;
+        if (empty($value)) {
+            throw new CloudTaskCannotBeValidException('Required field `'.$key.'` missing from task body payload');
+        }
+
+        return $value;
+    }
+
 }

--- a/src/TestHelpers/Client/MockCloudTaskCreator.php
+++ b/src/TestHelpers/Client/MockCloudTaskCreator.php
@@ -60,6 +60,19 @@ class MockCloudTaskCreator implements TaskCreator
     }
 
     /**
+     * Assert that exactly one task was created, and that it had the expected type
+     *
+     * @param string $expect_task_type
+     */
+    public function assertQueuedExactlyOne(string $expect_task_type): void
+    {
+        Assert::assertSame(
+            [$expect_task_type],
+            \array_map(fn(array $t) => $t['task_type'], $this->calls)
+        );
+    }
+
+    /**
      * Convert all options values to scalars that can be compared with strict equality
      *
      * The testcase will almost never have the actual object instances that were passed for schedule_send_after

--- a/src/TestHelpers/Server/TaskRequestStub.php
+++ b/src/TestHelpers/Server/TaskRequestStub.php
@@ -27,6 +27,7 @@ class TaskRequestStub extends TaskRequest
             'task_type'    => 'some-task',
             'headers'      => [],
             'caller_email' => NULL,
+            'parsed_body'  => NULL,
         ];
         $options  = AssociativeArrayUtils::deepMerge($defaults, $options);
 
@@ -35,11 +36,12 @@ class TaskRequestStub extends TaskRequest
             $options['url'],
             $options['headers']
         );
+        $request = $request->withQueryParams($options['query']);
+        if (isset($options['parsed_body'])) {
+            $request = $request->withParsedBody($options['parsed_body']);
+        }
 
-        $req               = new TaskRequest(
-            $request->withQueryParams($options['query']),
-            $options['task_type']
-        );
+        $req               = new TaskRequest($request, $options['task_type']);
         $req->caller_email = $options['caller_email'];
 
         return $req;

--- a/test/unit/Server/TaskRequestTest.php
+++ b/test/unit/Server/TaskRequestTest.php
@@ -156,6 +156,28 @@ class TaskRequestTest extends TestCase
         $subject->requireQueryParam('foo');
     }
 
+    public function test_its_require_body_field_returns_value()
+    {
+        $this->http_req = $this->http_req->withParsedBody(['some_payload_field' => 'My value']);
+        $subject        = $this->newSubject();
+        $this->assertSame('My value', $subject->requireBodyField('some_payload_field'));
+    }
+
+    /**
+     * @testWith [null]
+     *           [[]]
+     *           [{"other": "things"}]
+     *           [{"anything": null}]
+     *           [{"anything": ""}]
+     */
+    public function test_its_require_body_field_throws_if_value_missing_or_empty($body)
+    {
+        $this->http_req = $this->http_req->withParsedBody($body);
+        $subject        = $this->newSubject();
+        $this->expectException(CloudTaskCannotBeValidException::class);
+        $subject->requireBodyField('anything');
+    }
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
These have always been available through the underlying psr7
request instance, but were hard to stub for testing or require
from application code. This commit provides a similar layer of
sugar to what we already have for querystring variables.