### PR TITLE
Support a custom audience for cloud tasks auth tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
+* Support a `custom_token_audience` in the TaskType options, to allow specifying a non-default `audience` in the JWT
+  that Cloud Tasks issues to authorise the request.
+
 * Add support for PHP 8.2
+
 * Drop support for PHP 8.0
 
 ## v0.5.0 (2022-10-17)

--- a/src/Client/CreateTaskOptions.php
+++ b/src/Client/CreateTaskOptions.php
@@ -156,7 +156,7 @@ class CreateTaskOptions
         }
 
         if ($this->throttle_interval) {
-            $this->parseThrottleOptions($options);
+            $this->parseThrottleOptions();
         }
         if ($this->task_id_hash_options) {
             $this->appendOptionsToTaskIdFrom();

--- a/src/TaskTypeConfig.php
+++ b/src/TaskTypeConfig.php
@@ -41,6 +41,13 @@ class TaskTypeConfig
     protected string $signer_email;
 
     /**
+     * Optional value to use as the `audience` of the JWT issued to authorise requests as this task type.
+     *
+     * If left empty, cloud tasks will use the complete handler_url.
+     */
+    protected ?string $custom_token_audience = null;
+
+    /**
      * Internal application-specific identifier for this task type
      *
      * @var string
@@ -87,6 +94,11 @@ class TaskTypeConfig
     public function getSignerEmail(): string
     {
         return $this->signer_email;
+    }
+
+    public function getCustomTokenAudience(): ?string
+    {
+        return $this->custom_token_audience;
     }
 
     /**

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
+ini_set('date.timezone', 'UTC');
 
 // Currently phpunit's default error handling doesn't properly catch warnings / errors from data providers
 // https://github.com/sebastianbergmann/phpunit/issues/2449

--- a/test/unit/Client/CloudTaskCreatorTest.php
+++ b/test/unit/Client/CloudTaskCreatorTest.php
@@ -76,6 +76,24 @@ class CloudTaskCreatorTest extends TestCase
     }
 
     /**
+     * @testWith [{"custom_token_audience": null}, ""]
+     *           [{}, ""]
+     *           [{"custom_token_audience": "pick-me!"}, "pick-me!"]
+     */
+    public function test_it_configures_custom_audience_for_authenticated_task_if_configured($config, $expect)
+    {
+        $this->task_config = TaskTypeConfigStub::withTaskType(
+            'do-something',
+            ['signer_email' => 'someone@service.com', ...$config]
+        );
+        $this->newSubject()->create('do-something');
+
+        $task = $this->tasks_client->assertCreatedOneTask();
+        $this->assertTrue($task->getHttpRequest()->hasOidcToken(), 'should have oidc token');
+        $this->assertSame($expect, $task->getHttpRequest()->getOidcToken()->getAudience());
+    }
+
+    /**
      * @testWith [[], "https://my.handler.foo/something"]
      *           [{"query": {"id": 15, "scope": "any"}}, "https://my.handler.foo/something?id=15&scope=any"]
      */

--- a/test/unit/Client/CreateTaskOptionsTest.php
+++ b/test/unit/Client/CreateTaskOptionsTest.php
@@ -71,7 +71,7 @@ class CreateTaskOptionsTest extends TestCase
     public function test_it_throws_on_construction_with_invalid_args($args, $expect_msg)
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectErrorMessage($expect_msg);
+        $this->expectExceptionMessage($expect_msg);
         new CreateTaskOptions($args);
     }
 

--- a/test/unit/TaskTypeConfigProviderTest.php
+++ b/test/unit/TaskTypeConfigProviderTest.php
@@ -69,8 +69,16 @@ class TaskTypeConfigProviderTest extends TestCase
         ];
         $cfg          = $this->newSubject()->getConfig('do-a-thing');
         $this->assertSame(
-            ['type' => 'do-a-thing', 'signer' => 'neil@armstrong.serviceaccount.test'],
-            ['type' => $cfg->getTaskType(), 'signer' => $cfg->getSignerEmail()],
+            [
+                'type'     => 'do-a-thing',
+                'signer'   => 'neil@armstrong.serviceaccount.test',
+                'audience' => NULL,
+            ],
+            [
+                'type'     => $cfg->getTaskType(),
+                'signer'   => $cfg->getSignerEmail(),
+                'audience' => $cfg->getCustomTokenAudience(),
+            ],
         );
     }
 
@@ -101,15 +109,34 @@ class TaskTypeConfigProviderTest extends TestCase
                 'queue_path' => CloudTasksClient::queueName('good-proj', 'the-moon', 'unimportant'),
                 'handler'    => 'https://glacier.test/background',
                 'signer'     => 'neil@armstrong.serviceaccount.test',
+                'audience' => null,
             ],
             [
                 'queue_path' => $cfg->getQueuePath(),
                 'handler'    => $cfg->getHandlerUrl(),
                 'signer'     => $cfg->getSignerEmail(),
+                'audience' => $cfg->getCustomTokenAudience(),
             ]
         );
     }
 
+    public function test_it_can_provide_custom_token_audience_if_configured()
+    {
+        $this->config = [
+            'do-a-thing' => [
+                'queue'                 => [
+                    'project'  => 'good-proj',
+                    'location' => 'the-moon',
+                    'name'     => 'slow-stuff',
+                ],
+                'signer_email'          => 'neil@armstrong.serviceaccount.test',
+                'handler_url'           => 'https://moon.test/my-task',
+                'custom_token_audience' => 'pick me!',
+            ],
+        ];
+        $cfg          = $this->newSubject()->getConfig('do-a-thing');
+        $this->assertSame('pick me!', $cfg->getCustomTokenAudience());
+    }
 
     public function test_it_provides_default_creation_retry_options_if_none_provided()
     {


### PR DESCRIPTION
By default cloud tasks generates an auth token for outbound requests with an `audience` of the complete URL that is being called. 

Some services need to have a different value - e.g. Cloud Run needs just the base URL of the service. Allow this to be customised for specific task types.