### PR TITLE
Support psr/http-message:^2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## v0.5.5 (2024-02-14)
+
+* Support psr/http-message:^2.0
+
 ## v0.5.4 (2024-02-07)
 
 * Support ingenerator/php-utils:^2.0

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "google/protobuf": "^3.22.0",
         "ingenerator/oidc-token-verifier": "^0.3 || ^1.0",
         "ingenerator/php-utils": "^1.13 || ^2.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "fig/log-test": "^1.1",


### PR DESCRIPTION
It only adds parameter and return types, which we're compatible with.