### PR TITLE
Use latest google/gax InsecureCredentialsWrapper instead of cloud-core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,32 @@ jobs:
             dependencies: 'lowest'
           - php_version: '8.2'
             dependencies: 'lowest'
+    env:
+      php_extensions: grpc, protobuf
     steps:
+
+      - name: Setup extension cache
+        id: extension_cache
+        uses: shivammathur/cache-extensions@v1
+        with:
+          php-version: ${{ matrix.php_version }}
+          extensions: ${{ env.php_extensions }}
+          # NB the extension cache has an indefinite expiry, manually bump this key to trigger extension updates
+          key: extensions-cache-v1
+
+      - name: Cache extensions
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.extension_cache.outputs.dir }}
+          key: ${{ steps.extension_cache.outputs.key }}
+          restore-keys: ${{ steps.extension_cache.outputs.key }}
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php_version }}
           tools: composer:v2
+          extensions: ${{ env.php_extensions }}
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## v0.5.6 (2024-02-28)
+
+* Require google/gax:^1.29.1 for the new InsecureCredentialsWrapper class for emulator connections.
+  Google have moved this class to google/gax (from google/cloud-core) as part of the followup to the
+  gax release that broke the cloud-core version. We can now require that directly, because 
+  google/cloud-tasks already requires it. This also means that consuming projects no longer need to
+  explicitly require google/cloud-core just to use a Cloud Tasks emulator.
+
 ## v0.5.5 (2024-02-14)
 
 * Support psr/http-message:^2.0

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
+        "ext-grpc": "*",
         "fig/log-test": "^1.1",
         "guzzlehttp/psr7": "^2.6",
         "phpunit/phpunit": "^9.5.5"

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": "~8.1.0 || ~8.2.0",
         "ext-bcmath": "*",
         "google/cloud-tasks": "^1.8",
+        "google/gax": "^1.29.1",
         "google/protobuf": "^3.22.0",
         "ingenerator/oidc-token-verifier": "^0.3 || ^1.0",
         "ingenerator/php-utils": "^1.13 || ^2.0",
@@ -21,15 +22,8 @@
     },
     "require-dev": {
         "fig/log-test": "^1.1",
-        "google/cloud-core": "^1.14.4",
         "guzzlehttp/psr7": "^2.6",
         "phpunit/phpunit": "^9.5.5"
-    },
-    "conflict": {
-        "google/gax": "<1.16"
-    },
-    "suggest": {
-        "google/cloud-core": "You need google/cloud-core >1.44.4 to use a cloud tasks emulator with insecure credentials"
     },
     "repositories": [
         {"type": "composer", "url": "https://php-packages.ingenerator.com"}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "fig/log-test": "^1.1",
         "google/cloud-core": "^1.14.4",
-        "guzzlehttp/psr7": "^1.7",
+        "guzzlehttp/psr7": "^2.6",
         "phpunit/phpunit": "^9.5.5"
     },
     "conflict": {

--- a/src/Client/CloudTasksClientFactory.php
+++ b/src/Client/CloudTasksClientFactory.php
@@ -4,7 +4,7 @@
 namespace Ingenerator\CloudTasksWrapper\Client;
 
 
-use Google\Cloud\Core\InsecureCredentialsWrapper;
+use Google\ApiCore\InsecureCredentialsWrapper;
 use Google\Cloud\Tasks\V2\CloudTasksClient;
 use Grpc\Channel;
 use Grpc\ChannelCredentials;
@@ -21,10 +21,6 @@ class CloudTasksClientFactory
         ];
 
         if ($config['use_emulator']) {
-            if (!class_exists(InsecureCredentialsWrapper::class)) {
-                throw new RuntimeException(
-                    'You need google/cloud-core >1.44.4 to use a cloud tasks emulator with insecure credentials');
-            }
             $options = array_merge(
                 $base_options,
                 [

--- a/test/integration/CloudTasksClientFactoryTest.php
+++ b/test/integration/CloudTasksClientFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace test\integration;
+
+use Google\ApiCore\CredentialsWrapper;
+use Google\Cloud\Tasks\V2\CloudTasksClient;
+use Ingenerator\CloudTasksWrapper\Client\CloudTasksClientFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+
+class CloudTasksClientFactoryTest extends TestCase
+{
+
+    public function test_it_can_create_client_when_called_with_emulator_configuration()
+    {
+        $cache = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();
+        $client = CloudTasksClientFactory::makeClient($cache, [
+            'use_emulator' => true,
+            'emulator_endpoint' => 'cloud_tasks_emulator:8123',
+            'credentials' => null
+        ]);
+        $this->assertInstanceOf(CloudTasksClient::class, $client);
+    }
+
+    public function test_it_can_create_client_when_called_with_production_configuration()
+    {
+        $cache = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();
+        $client = CloudTasksClientFactory::makeClient($cache, [
+            'use_emulator' => false,
+            // NB that the emulator_endpoint is not relevant here, but it doesn't matter
+            // if a project still provides it.
+            'emulator_endpoint' => 'cloud_tasks_emulator:8123',
+            'credentials' => $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock(),
+        ]);
+        $this->assertInstanceOf(CloudTasksClient::class, $client);
+    }
+}


### PR DESCRIPTION
Google have moved this class to google/gax (from google/cloud-core) as part of the
followup to the gax release that broke the cloud-core version. 

We can now require google/gax directly, because google/cloud-tasks already requires
it. This also means that consuming projects no longer need to explicitly require 
google/cloud-core just to use a Cloud Tasks emulator.

Also resolves an outdated dev dependency that was holding back various google SDKs
when testing this package.